### PR TITLE
Fix - User stuck when trying to input name during new high score event

### DIFF
--- a/internal/app/game/control.go
+++ b/internal/app/game/control.go
@@ -49,11 +49,12 @@ func HandleGameOver(score int) {
 					fmt.Printf("%d. %-20s %d\n", i+1, score.Name, score.Score)
 				}
 				fmt.Println("--------------------")
-				fmt.Println("Press any key to exit...")
-				return
 			}
 		}
 	}
+
+	fmt.Println("Press Enter to exit...")
+	_, _ = bufio.NewReader(os.Stdin).ReadString('\n')
 }
 
 // GetPlayerName prompts for and returns the player's name

--- a/internal/app/game/control.go
+++ b/internal/app/game/control.go
@@ -11,7 +11,14 @@ import (
 
 func HandleInput(jumpChan chan bool, exitChan chan bool) {
 	for {
-		char, key, _ := keyboard.GetKey()
+		char, key, err := keyboard.GetKey()
+		if err != nil {
+			select {
+			case exitChan <- true:
+			default:
+			}
+			return
+		}
 
 		if key == keyboard.KeySpace || char == ' ' {
 			jumpChan <- true

--- a/internal/app/scenes/render.go
+++ b/internal/app/scenes/render.go
@@ -79,7 +79,7 @@ func AreClashing(
 	return false
 }
 
-// RenderFinalFrame renders the last frame of the game with the game over message
+// RenderFinalFrame renders the last frame of the game
 // while maintaining the alternate buffer to prevent scrollback
 func RenderFinalFrame(scene []string, score int) {
 	var output strings.Builder
@@ -94,9 +94,6 @@ func RenderFinalFrame(scene []string, score int) {
 		output.WriteString(line + "\n")
 	}
 
-	// Print game over message below the frame
-	output.WriteString("\nGame Over!\n")
-	output.WriteString("Press any key to exit...")
 	fmt.Print(output.String())
 }
 

--- a/main.go
+++ b/main.go
@@ -45,9 +45,9 @@ func main() {
 	// Set up the deferred end sequence
 	defer func() {
 		scores.Stop()
+		_ = keyboard.Close()
 		gameOverScore = scores.Print()
 		game.HandleGameOver(gameOverScore)
-		_ = keyboard.Close()
 	}()
 
 	dino.Init(30)

--- a/main.go
+++ b/main.go
@@ -28,8 +28,8 @@ func main() {
 		groundSpeed         int           = 1
 		gameSpeed           time.Duration = 15
 		delayBetweenEnemies int           = 20
-		jumpChan            chan bool     = make(chan bool)
-		exitChan            chan bool     = make(chan bool)
+		jumpChan            chan bool     = make(chan bool, 1)
+		exitChan            chan bool     = make(chan bool, 1)
 		dino                sprites.SpriteDino
 		cactuses            sprites.SpriteCactuses
 		pteranodons         sprites.SpritePteranodons
@@ -45,6 +45,8 @@ func main() {
 	// Set up the deferred end sequence
 	defer func() {
 		scores.Stop()
+		spawnCactusTicker.Stop()
+		spawnPteraTicker.Stop()
 		_ = keyboard.Close()
 		gameOverScore = scores.Print()
 		game.HandleGameOver(gameOverScore)


### PR DESCRIPTION
This pull request improves the game's input handling and exit flow, making it more robust against input errors and providing a clearer exit prompt for users. It also updates the rendering logic to streamline the final game frame and ensures proper cleanup of resources.

**Input handling and exit flow improvements:**
- Added error handling for keyboard input in `HandleInput`, so the game exits gracefully if an input error occurs by signaling through `exitChan`.
- Changed the exit prompt after game over to "Press Enter to exit..." and waits for the Enter key, instead of "Press any key to exit...".
- Updated `jumpChan` and `exitChan` channels to be buffered, preventing potential blocking issues.

**Resource cleanup:**
- Ensured that tickers (`spawnCactusTicker`, `spawnPteraTicker`) are stopped and the keyboard is closed properly in the deferred cleanup function.

**Rendering adjustments:**
- Removed the game over message and exit prompt from the final frame rendering logic, centralizing exit messaging in the control flow instead.
- Updated the comment for `RenderFinalFrame` to reflect its new responsibility.